### PR TITLE
Add redirect for kitchenReno gallery

### DIFF
--- a/BlazorGitHubPagesTucker/Pages/KitchenReno.razor
+++ b/BlazorGitHubPagesTucker/Pages/KitchenReno.razor
@@ -1,0 +1,14 @@
+@page "/kitchenReno"
+@page "/kitchenreno"
+@inject NavigationManager Navigation
+
+<PageTitle>Kitchen Reno</PageTitle>
+
+<h1>Redirecting...</h1>
+
+@code {
+    protected override void OnInitialized()
+    {
+        Navigation.NavigateTo("https://photos.app.goo.gl/J9F8DQ2NDrxoEPR4A", true);
+    }
+}

--- a/BlazorGitHubPagesTucker/_Imports.razor
+++ b/BlazorGitHubPagesTucker/_Imports.razor
@@ -5,6 +5,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.AspNetCore.Components
 @using Microsoft.JSInterop
 @using BlazorGitHubPagesTucker
 @using BlazorGitHubPagesTucker.Shared


### PR DESCRIPTION
## Summary
- add a Blazor page at `/kitchenReno` (and lowercase) that redirects to the Google Photos album
- update shared imports so NavigationManager is available for the new page

## Testing
- dotnet build *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c05d7ffd88328ba81f40a854cb7b4)